### PR TITLE
Website updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
 
 				<h3>December 14th, 2017</h3>
 				<p class="text" style="text-align: center">The FCC votes 3-2 to reclassify internet service providers under Title I, repealing net neutrality regulations.</p>
-				<p class="text" style="text-align: center"><a href="https://arstechnica.com/tech-policy/2017/12/state-attorneys-general-line-up-to-sue-fcc-over-net-neutrality-repeal/">New York attorney general Eric Schneiderman, joined by attorneys general from states such as Massachusetts, California, Oregon, Illinois, Iowa, Washington, and Minnesota.</a></p>
+				<p class="text" style="text-align: center"><a href="https://arstechnica.com/tech-policy/2017/12/state-attorneys-general-line-up-to-sue-fcc-over-net-neutrality-repeal/">New York attorney general Eric Schneiderman stated that he would launch a suit over the FCC's handling of fake comments. He is joined by attorneys general from states such as Massachusetts, California, Oregon, Illinois, Iowa, Washington, and Minnesota.</a></p>
 				<p class="text" style="text-align: center"><a href="https://twitter.com/SenMarkey/status/941378914185895936">Senator Ed Markey (D-MA) announced that he will introduce a Congressional Review Act which would restore net neutrality regulations.</a></p>
 
 				<h3>July 13th, 2017</h3>

--- a/index.html
+++ b/index.html
@@ -89,6 +89,9 @@
 					<li>
 						<a class="nav-item" href="mail.html">Tools</a>
 					</li>
+					<li>
+						<a class="nav-item" href="/blog">Blog</a>
+					</li>
 				</ul>
 			</div>
 			<!-- /.navbar-collapse -->

--- a/index.html
+++ b/index.html
@@ -119,26 +119,36 @@
 			<div class="col-lg-8 col-lg-offset-2">
 				<h2>Recent Developments</h2>
 
+				<h3>January 1, 2017</h3>
+				<p class="text" style="text-align: center"><a href="https://keepournetfree.org/blog">KeepOurNetFree's blog is launched.</a></p>
 
-				<h3>July 13th 2017</h3>
+				<h3>December 19th, 2017</h3>
+				<p class="text" style="text-align: center"><a href="https://www.congress.gov/bill/115th-congress/house-bill/4682/text">Representative Marsha Blackburn (R-TN) introduces an anti-net neutrality bill designed to prevent states or a future FCC enforcing Title II regulations.</a></p>
+
+				<h3>December 14th, 2017</h3>
+				<p class="text" style="text-align: center">The FCC votes 3-2 to reclassify internet service providers under Title I, repealing net neutrality regulations.</p>
+				<p class="text" style="text-align: center"><a href="https://arstechnica.com/tech-policy/2017/12/state-attorneys-general-line-up-to-sue-fcc-over-net-neutrality-repeal/">New York attorney general Eric Schneiderman, joined by attorneys general from states such as Massachusetts, California, Oregon, Illinois, Iowa, Washington, and Minnesota.</a></p>
+				<p class="text" style="text-align: center"><a href="https://twitter.com/SenMarkey/status/941378914185895936">Senator Ed Markey (D-MA) announced that he will introduce a Congressional Review Act which would restore net neutrality regulations.</a></p>
+
+				<h3>July 13th, 2017</h3>
 				<p class="text" style="text-align: center"><a href="http://imgur.com/a/vYVet">The Internet wide day of action was a rousing success!</a></p>
 
 
-				<h3>July 12th 2017</h3>
+				<h3>July 12th, 2017</h3>
 				<p class="text" style="text-align: center">Today is the Internet wide day of action to save net neutrality.  More information on <a href="https://www.battleforthenet.com/july12/">www.battleforthenet.com</a></p>
 
 
-				<h3>May 29th 2017</h3>
+				<h3>May 29th, 2017</h3>
 				<p class="text" style="text-align: center">KeepOurNetFree releases <a href="https://chrome.google.com/webstore/detail/removal-of-net-neutrality/macmdnlopncdoehmjhfenfblflnohoen">Removal of Net Neutrality Simulator</a>.  A Chrome plugin that simulates what the Internet would look like without net neutrality.</p>
 
 				<br><br>
 
-				<h3>May 18th 2017</h3>
+				<h3>May 18th, 2017</h3>
 				<p class="text" style="text-align: center">The FCC votes 2-1 to <a href="https://arstechnica.com/tech-policy/2017/05/net-neutrality-goes-down-in-flames-as-fcc-votes-to-kill-title-ii-rules/">remove net neutrality regulations</a>.</p>
 
 				<br><br>
 
-				<h3>May 12th 2017</h3>
+				<h3>May 12th, 2017</h3>
 				<p class="text" style="text-align: center">KeepOurNetFree launches an initiative to send physical mail to the FCC in support of net neutrality.
 				<br><br>
 				Send mail to:
@@ -151,17 +161,17 @@
 
 				<br><br>
 
-				<h3>May 10th 2017</h3>
+				<h3>May 10th, 2017</h3>
 				<p class="text" style="text-align: center">It is revealed that a bot spammed the FCC with over <a href="https://www.theverge.com/2017/5/10/15610744/anti-net-neutrality-fake-comments-identities">100,000 fake comments in favor of removing net neutrality</a>.
 
 				<br><br>
 
-				<h3>May 8th 2017</h3>
+				<h3>May 8th, 2017</h3>
 				<p class="text" style="text-align: center">The FCC <a href="http://transition.fcc.gov/Daily_Releases/Daily_Business/2017/db0508/DOC-344764A1.pdf">claims it was DDoS’d</a> following John Oliver’s launch of <a href="http://gofccyourself.com">www.gofccyourself.com</a>.</p>
 
 				<br><br>
 
-				<h3>May 6th 2017</h3>
+				<h3>May 6th, 2017</h3>
 				<p class="text" style="text-align: center">John Oliver does a show about net neutrality making a call to action to comment on the FCC’s proposal using the website <a href="http://gofccyourself.com">www.gofccyourself.com</a>.</p>
 
 				<br><br>


### PR DESCRIPTION
I've added a little here to bring the blog up to date as of today (01/02/2018). Summary of changes:

Added info to "Recent Developments" about:

- FCC's net neutrality repeal
- Eric Schneiderman's (New York attorney general) comment lawsuit
- Ed Markey's (senator D-MA) Congressional Review Act to revert the FCC ruling
- Marsha Blackburn's anti-net neutrality bill
- Our new blog

Added blog link to navbar

Minor wording/comma additions