### PR TITLE
Make links not the whole text

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,15 +123,15 @@
 				<h2>Recent Developments</h2>
 
 				<h3>January 1, 2017</h3>
-				<p class="text" style="text-align: center"><a href="https://keepournetfree.org/blog">KeepOurNetFree's blog is launched.</a></p>
+				<p class="text" style="text-align: center">KeepOurNetFree's <a href="https://keepournetfree.org/blog">blog</a> is launched.</p>
 
 				<h3>December 19th, 2017</h3>
-				<p class="text" style="text-align: center"><a href="https://www.congress.gov/bill/115th-congress/house-bill/4682/text">Representative Marsha Blackburn (R-TN) introduces an anti-net neutrality bill designed to prevent states or a future FCC enforcing Title II regulations.</a></p>
+				<p class="text" style="text-align: center">Representative Marsha Blackburn (R-TN) introduces an <a href="https://www.congress.gov/bill/115th-congress/house-bill/4682/text">anti-net neutrality bill (H.R. 4682)</a> designed to prevent states or a future FCC enforcing Title II regulations.</p>
 
 				<h3>December 14th, 2017</h3>
 				<p class="text" style="text-align: center">The FCC votes 3-2 to reclassify internet service providers under Title I, repealing net neutrality regulations.</p>
-				<p class="text" style="text-align: center"><a href="https://arstechnica.com/tech-policy/2017/12/state-attorneys-general-line-up-to-sue-fcc-over-net-neutrality-repeal/">New York attorney general Eric Schneiderman stated that he would launch a suit over the FCC's handling of fake comments. He is joined by attorneys general from states such as Massachusetts, California, Oregon, Illinois, Iowa, Washington, and Minnesota.</a></p>
-				<p class="text" style="text-align: center"><a href="https://twitter.com/SenMarkey/status/941378914185895936">Senator Ed Markey (D-MA) announced that he will introduce a Congressional Review Act which would restore net neutrality regulations.</a></p>
+				<p class="text" style="text-align: center">New York attorney general Eric Schneiderman stated that he would <a href="https://arstechnica.com/tech-policy/2017/12/state-attorneys-general-line-up-to-sue-fcc-over-net-neutrality-repeal/">launch a suit</a> over the FCC's handling of fake comments. He is joined by attorneys general from states such as Massachusetts, California, Oregon, Illinois, Iowa, Washington, and Minnesota.</p>
+				<p class="text" style="text-align: center">Senator Ed Markey (D-MA) announced that he will introduce a <a href="https://twitter.com/SenMarkey/status/941378914185895936">Congressional Review Act</a> which would restore net neutrality regulations.</p>
 
 				<h3>July 13th, 2017</h3>
 				<p class="text" style="text-align: center"><a href="http://imgur.com/a/vYVet">The Internet wide day of action was a rousing success!</a></p>


### PR DESCRIPTION
Links are now not the whole text for some of the latest developments. We can delete the branch once this is merged.